### PR TITLE
Improve name and RUT handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,12 @@ uvicorn main:app --reload
 ```
 
 4. Abre `web/index.html` en tu navegador.
+
+El bot ahora puede recordar tu nombre o RUT si los envías por separado. Si solo
+envías tu nombre, se te solicitará el RUT en el siguiente mensaje y viceversa.
+
+Para ejecutar las pruebas:
+```
+pip install -r requirements.txt
+pytest
+```

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   </style>
 </head>
 <body>
-  <h2>LitioGPT 0.10.1</h2>
+  <h2>LitioGPT 0.10.2</h2>
   <div class="chat-box" id="chat"></div>
   <textarea id="input" placeholder="Escribe tu mensaje aquí..."></textarea>
   <button onclick="enviarMensaje()">Enviar</button>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 openai>=1.0.0
 python-dotenv
+pytest

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from main import extraer_nombre, extraer_rut, normalizar_rut
+
+
+def test_extraer_nombre_introductory():
+    assert extraer_nombre("hola, soy xavier martin 17088198-2") == "Xavier Martin"
+
+
+def test_extraer_nombre_rut_prepend():
+    assert extraer_nombre("17088198-2 xavier martin") == "Xavier Martin"
+
+
+def test_extraer_nombre_middle_rut_word():
+    assert extraer_nombre("xavier martin rut 17088198-2") == "Xavier Martin"
+
+
+def test_extraer_nombre_rut_first():
+    assert extraer_nombre("rut 17088198-2 xavier martin") == "Xavier Martin"
+
+
+def test_extraer_rut_formats():
+    assert extraer_rut("17088198-2") == "17088198-2"
+    assert extraer_rut("17.088.198-2") == "17088198-2"
+    assert extraer_rut("170881982") == "170881982"
+
+
+def test_normalizar_rut():
+    assert normalizar_rut("17088198-2") == "17088198-2"
+    assert normalizar_rut("17.088.198-2") == "17088198-2"
+    assert normalizar_rut("170881982") == "17088198-2"
+    assert normalizar_rut("invalid") == ""
+


### PR DESCRIPTION
## Summary
- remember partial name or RUT between messages
- better extraction of name and RUT
- bump frontend version
- add tests for parsing helpers
- document conversation flow and testing steps

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842667f15b08322842250d0857a3b04