### PR TITLE
Improve name parsing for introductory phrases

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,12 @@ pip install -r requirements.txt
 uvicorn main:app --reload
 ```
 
-4. Abre `web/index.html` en tu navegador.
+4. Visita `http://localhost:8000/` en tu navegador.
+
+El bot recuerda tu nombre o RUT si los envías por separado. Una vez que se registran ambos datos, te consultará si estás tomando litio para ofrecerte acompañamiento personalizado. Si no logra identificar tus datos, de todas formas seguirá la conversación preguntando cómo te sientes.
+
+Para ejecutar las pruebas:
+```
+pip install -r requirements.txt
+pytest
+```

--- a/index.html
+++ b/index.html
@@ -4,17 +4,17 @@
   <meta charset="UTF-8" />
   <title>LitioGPT</title>
   <style>
-    body { font-family: Arial, sans-serif; max-width: 600px; margin: auto; padding: 1rem; background: #f7f7f7; }
-    h2 { text-align: center; }
-    .chat-box { background: white; border: 1px solid #ccc; border-radius: 5px; padding: 1rem; height: 400px; overflow-y: auto; margin-bottom: 1rem; }
-    .mensaje-paciente { color: black; background: #e0f0ff; padding: 0.5rem; border-radius: 5px; margin-bottom: 0.5rem; }
-    .mensaje-bot { color: white; background: #0077cc; padding: 0.5rem; border-radius: 5px; margin-bottom: 0.5rem; text-align: right; }
-    textarea { width: 100%; height: 70px; resize: none; }
-    button { background: #0077cc; color: white; border: none; padding: 0.5rem 1rem; border-radius: 5px; cursor: pointer; margin-top: 0.5rem; float: right; }
+    body { font-family: Arial, sans-serif; max-width: 700px; margin: auto; padding: 1rem; background: linear-gradient(#eef2f5, #dfe7ec); color: #222; }
+    h2 { text-align: center; margin-bottom: 1rem; }
+    .chat-box { background: white; border: 1px solid #ccc; border-radius: 8px; padding: 1rem; height: 420px; overflow-y: auto; margin-bottom: 1rem; }
+    .mensaje-paciente { background: #e0f0ff; padding: 0.5rem; border-radius: 8px; margin-bottom: 0.5rem; }
+    .mensaje-bot { background: #0077cc; color: white; padding: 0.5rem; border-radius: 8px; margin-bottom: 0.5rem; text-align: right; }
+    textarea { width: 100%; height: 70px; resize: none; border-radius: 8px; padding: 0.5rem; border: 1px solid #ccc; }
+    button { background: #0077cc; color: white; border: none; padding: 0.5rem 1rem; border-radius: 8px; cursor: pointer; margin-top: 0.5rem; float: right; }
   </style>
 </head>
 <body>
-  <h2>LitioGPT 0.10.1</h2>
+  <h2>LitioGPT 0.11.1</h2>
   <div class="chat-box" id="chat"></div>
   <textarea id="input" placeholder="Escribe tu mensaje aquí..."></textarea>
   <button onclick="enviarMensaje()">Enviar</button>

--- a/main.py
+++ b/main.py
@@ -24,10 +24,16 @@ class Message(BaseModel):
     content: str
 
 pacientes_en_sesion = {}  # rut -> nombre
+nombre_pendiente = ""
+rut_pendiente = ""
+rut_en_conversacion = ""
+esperando_respuesta_litio = False
 @app.post("/mensaje")
 async def recibir_mensaje(message: Message):
+    global nombre_pendiente, rut_pendiente, rut_en_conversacion, esperando_respuesta_litio
     client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     texto = message.content
+    prefijo = ""
 
     nombre = extraer_nombre(texto)
     rut = normalizar_rut(extraer_rut(texto))
@@ -35,18 +41,58 @@ async def recibir_mensaje(message: Message):
 
     print("DEBUG | Nombre extraído:", nombre, "| RUT normalizado:", rut)
 
+    if esperando_respuesta_litio and rut_en_conversacion:
+        esperando_respuesta_litio = False
+        if "no" in texto.lower():
+            return {"respuesta": "Entiendo, si en algún momento comienzas un tratamiento con litio avísame para acompañarte."}
+        return {"respuesta": "Perfecto, seguimos atentos a tus síntomas y dudas."}
+
     if rut in pacientes_en_sesion:
         nombre = pacientes_en_sesion[rut]
+        rut_en_conversacion = rut
     elif nombre and rut:
         pacientes_en_sesion[rut] = nombre
+        rut_en_conversacion = rut
+        nombre_pendiente = ""
+        rut_pendiente = ""
+        esperando_respuesta_litio = True
+        return {"respuesta": f"Gracias {nombre.split()[0]}, ¿estás tomando litio actualmente?"}
+    elif nombre and not rut:
+        nombre_pendiente = nombre
+        if rut_pendiente:
+            pacientes_en_sesion[rut_pendiente] = nombre
+            rut_en_conversacion = rut_pendiente
+            rut = rut_pendiente
+            nombre_pendiente = ""
+            rut_pendiente = ""
+            esperando_respuesta_litio = True
+            return {"respuesta": f"Gracias {nombre.split()[0]}, ¿estás tomando litio actualmente?"}
+        else:
+            registrar_rut_fallido(texto, nombre, rut)
+            return {"respuesta": f"Gracias {nombre.split()[0]}, ¿podrías indicarme tu RUT?"}
+    elif rut and not nombre:
+        rut_pendiente = rut
+        if nombre_pendiente:
+            pacientes_en_sesion[rut] = nombre_pendiente
+            rut_en_conversacion = rut
+            nombre = nombre_pendiente
+            nombre_pendiente = ""
+            rut_pendiente = ""
+            esperando_respuesta_litio = True
+            return {"respuesta": f"Gracias {nombre.split()[0]}, ¿estás tomando litio actualmente?"}
+        else:
+            registrar_rut_fallido(texto, nombre, rut)
+            return {"respuesta": "Gracias. ¿Cuál es tu nombre completo?"}
     else:
-        registrar_rut_fallido(texto, nombre, rut)
-        respuesta_presentacion = (
-            "Hola, soy tu asistente médico. Estoy aquí para ayudarte a monitorear tu tratamiento con litio y tus síntomas. "
-            "Por ahora no pude registrar tu nombre o RUT correctamente, ya que soy un prototipo aún en desarrollo. "
-            "De todos modos, puedes contarme lo que te pasa y haré lo mejor posible por ayudarte."
-        )
-        return {"respuesta": respuesta_presentacion}
+        prefijo = ""
+        if rut_en_conversacion:
+            nombre = pacientes_en_sesion.get(rut_en_conversacion, "")
+        else:
+            registrar_rut_fallido(texto, nombre, rut)
+            prefijo = (
+                "Hola, soy tu asistente médico. Aún no logro registrar tu nombre o RUT. "
+                "Cuéntame, ¿cómo te sientes hoy? "
+            )
 
     if requiere_aclaracion(texto):
         return {"respuesta": "¿Podrías explicarme un poco más a qué te refieres con eso? Quiero entender bien para poder ayudarte mejor."}
@@ -58,14 +104,17 @@ async def recibir_mensaje(message: Message):
     respuesta = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[
-            {"role": "system", "content": "Eres un asistente médico experto en seguimiento de pacientes con litio. Evalúas criterios de gravedad de forma no sugestiva porque tus pacientes son vulnerables. Además, debes consultar al menos una vez a la semana sobre los síntomas suicidas y evaluar su gravedad según las escalas más modernas."},
+            {"role": "system", "content": "Eres un asistente médico experto en seguimiento de pacientes que toman litio. Respondes con empatía y de forma concisa. Evalúas criterios de gravedad de manera no sugestiva y preguntas al menos una vez por semana por síntomas suicidas."},
             {"role": "user", "content": texto}
         ]
     )
 
     contenido_respuesta = respuesta.choices[0].message.content
 
-    if "urgencias" in contenido_respuesta.lower():
+    if prefijo:
+        contenido_respuesta = prefijo + contenido_respuesta
+
+    if "urgencias" in contenido_respuesta.lower() or any(p in resumen for p in ["síntomas neurológicos", "ideas suicidas"]):
         enviar_correo_alerta(texto, contenido_respuesta)
 
     registrar_interaccion(nombre, rut, texto, contenido_respuesta, resumen)
@@ -107,8 +156,8 @@ def registrar_rut_fallido(texto, nombre, rut):
 
 def extraer_rut(texto):
     texto = texto.replace(".", "").replace(" ", "").lower()
-    posibles = re.findall(r"\b\d{7,8}-?[\dk]\b", texto)
-    return posibles[0] if posibles else ""
+    match = re.search(r"\d{7,8}-?[0-9k]", texto)
+    return match.group(0) if match else ""
 
 def normalizar_rut(rut):
     rut = rut.replace(".", "").replace(" ", "").upper()
@@ -119,13 +168,21 @@ def normalizar_rut(rut):
     return ""
 
 def extraer_nombre(texto):
-    texto_limpio = re.sub(r"\b\d{7,8}-?[\dk]\b", "", texto)  # eliminar posibles RUTs
-    texto_limpio = texto_limpio.lower()
-    texto_limpio = re.sub(r"mi nombre es|soy|me llamo", "", texto_limpio)
-    partes = texto_limpio.strip().split()
-    posibles = [p for p in partes if p.isalpha() and len(p) > 2]
-    if len(posibles) >= 2:
-        return f"{posibles[0].capitalize()} {posibles[1].capitalize()}"
+    texto_limpio = re.sub(r"\b\d{7,8}-?[0-9kK]\b", "", texto, flags=re.IGNORECASE)
+    texto_limpio = re.sub(r"\brut\b", "", texto_limpio, flags=re.IGNORECASE)
+
+    patron = re.compile(
+        r"(?:me\s+llamo|mi\s+nombre\s+es|soy)\s+" +
+        r"([A-Za-zÁÉÍÓÚáéíóúÑñ]{2,})\s+([A-Za-zÁÉÍÓÚáéíóúÑñ]{2,})",
+        flags=re.IGNORECASE,
+    )
+    m = patron.search(texto_limpio)
+    if m:
+        return f"{m.group(1).capitalize()} {m.group(2).capitalize()}"
+
+    palabras = re.findall(r"[A-Za-zÁÉÍÓÚáéíóúÑñ]{2,}", texto_limpio)
+    if len(palabras) >= 2:
+        return f"{palabras[-2].capitalize()} {palabras[-1].capitalize()}"
     return ""
 
 def requiere_aclaracion(texto):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 openai>=1.0.0
 python-dotenv
+pytest

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from main import extraer_nombre, extraer_rut, normalizar_rut
+
+
+def test_extraer_nombre_introductory():
+    assert extraer_nombre("hola, soy xavier martin 17088198-2") == "Xavier Martin"
+
+def test_extraer_nombre_intro_phrase():
+    frase = "me llamo xavier martin y mi rut es 17088198-2"
+    assert extraer_nombre(frase) == "Xavier Martin"
+
+
+def test_extraer_nombre_rut_prepend():
+    assert extraer_nombre("17088198-2 xavier martin") == "Xavier Martin"
+
+
+def test_extraer_nombre_middle_rut_word():
+    assert extraer_nombre("xavier martin rut 17088198-2") == "Xavier Martin"
+
+
+def test_extraer_nombre_rut_first():
+    assert extraer_nombre("rut 17088198-2 xavier martin") == "Xavier Martin"
+
+
+def test_extraer_rut_formats():
+    assert extraer_rut("17088198-2") == "17088198-2"
+    assert extraer_rut("17.088.198-2") == "17088198-2"
+    assert extraer_rut("170881982") == "170881982"
+
+
+def test_normalizar_rut():
+    assert normalizar_rut("17088198-2") == "17088198-2"
+    assert normalizar_rut("17.088.198-2") == "17088198-2"
+    assert normalizar_rut("170881982") == "17088198-2"
+    assert normalizar_rut("invalid") == ""
+


### PR DESCRIPTION
## Summary
- enhance `extraer_nombre` to detect names after introductory phrases
- add a test for "me llamo ..." case
- let the conversation continue if name or RUT can't be extracted
- bump web UI version to 0.11.1

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842667f15b08322842250d0857a3b04